### PR TITLE
Add multi-human evaluator

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "llm_eval"
-version = "1.4.1"
+version = "1.5.0"
 dependencies = [
   "numpy",
   "torch",

--- a/src/llm_eval/__init__.py
+++ b/src/llm_eval/__init__.py
@@ -1,6 +1,6 @@
 """Evaluation suite for LLMs on Core-Knowledge tasks."""
 
-__version__ = '1.4.1'
+__version__ = '1.5.0'
 """Version number of the package."""
 
 from .benchmark import create_benchmark

--- a/src/llm_eval/benchmark/base_benchmark.py
+++ b/src/llm_eval/benchmark/base_benchmark.py
@@ -225,13 +225,19 @@ class BaseBenchmark(ABC):
             # Otherwise, evaluate the prediction and store the result
             else:
                 result, info = evaluator.evaluate(question, prediction,
-                                                  acceptable_answers)
-                db.update_doc(BENCHMARK, self.BM_NAME, key,
-                              f'evaluation.{evaluator.hashval}',
-                              {'result': result, 'info': info})
-                
+                                                  acceptable_answers,
+                                                  doc=doc, db=db,
+                                                  bm_name=self.BM_NAME)
+                if result is not None:
+                    # Result can be None in case of Multi-Human Evaluator
+                    # because it stores its results into the `info` dicts
+                    # of other evals
+                    db.update_doc(BENCHMARK, self.BM_NAME, key,
+                                f'evaluation.{evaluator.hashval}',
+                                {'result': result, 'info': info})
+
             # Update the evaluation statistics
-            correct += int(result)
+            correct += 0 if result is None else int(result)
 
         # Return the final score
         return correct / self.total_questions

--- a/src/llm_eval/evaluator/__init__.py
+++ b/src/llm_eval/evaluator/__init__.py
@@ -6,7 +6,7 @@ logger = logging.getLogger('evaluator')
 from .base_evaluator import BaseEvaluator, DummyEvaluator
 from .classic_evaluator import (ExactMatchEvaluator, ContainsMatchEvaluator,
                                 ContainsWordsEvaluator)
-from .human_evaluator import HumanEvaluator
+from .human_evaluator import HumanEvaluator, MultiHumanEvaluator
 from .llm_evaluator import LLMEvaluator
 from .hf_evaluator import BERTEvaluator
 
@@ -18,6 +18,7 @@ classes = {
     'HumanEvaluator': HumanEvaluator,
     'LLMEvaluator': LLMEvaluator,
     'BERTEvaluator': BERTEvaluator,
+    'MultiHumanEvaluator': MultiHumanEvaluator,
     # Add new evaluators here
 }
 

--- a/src/llm_eval/evaluator/base_evaluator.py
+++ b/src/llm_eval/evaluator/base_evaluator.py
@@ -28,7 +28,6 @@ class BaseEvaluator(ABC):
         """Return the SHA256 hash of the evaluator's configuration as a base64
         string."""
 
-
     def exit(self):
         """Perform any necessary cleanup operations."""
         logger.log(UPDATE, 'Exiting evaluator: `%s`',

--- a/src/llm_eval/evaluator/human_evaluator.py
+++ b/src/llm_eval/evaluator/human_evaluator.py
@@ -4,8 +4,43 @@ from termcolor import colored
 from .base_evaluator import BaseEvaluator
 from .classic_evaluator import ExactMatchEvaluator
 from ..helpers import InfoDoc
+from ..helpers.constants.db import BENCHMARK
+
+
+VALID_INPUTS = ['y', 'n', 'yy', 'nn', 'y?', 'n?']
+
+
+def _get_human_eval(question, response, references) -> tuple[bool, dict]:
+    """Ask a human to evaluate the response."""
+
+    # Provide the user with the question, references, and response
+    print(colored('Question  :\n', 'red'),
+            textwrap.indent(colored(question, 'blue'), '  '))
+    print(colored('References:', 'red'))
+    for ref in references:
+        print(textwrap.indent(ref, '  '))
+    print(colored('Response  :\n', 'red'),
+            textwrap.indent(colored(response, 'green'), '  '))
+    print(colored('Evaluation:', 'red'))
+
+    # Get a valid user input
+    user_input = ''
+    while user_input not in VALID_INPUTS:
+        user_input = input().lower()
+        if user_input not in VALID_INPUTS:
+            print('Invalid input. Please enter one of',
+                    {', '.join(f"'{i}'" for i in VALID_INPUTS)})
+    print()
+
+    # Return the result
+    success = user_input in ['yy','y', 'y?']
+    info = {'confident': user_input in ['yy','nn', 'y', 'n']}
+    return success, info
+
 
 class HumanEvaluator(BaseEvaluator):
+    """Evaluator that asks a human to evaluate the response."""
+
     def __init__(self, eval_config: dict):
         self._eval_config = eval_config
         self._exact_match_evaluator = ExactMatchEvaluator({})
@@ -16,31 +51,82 @@ class HumanEvaluator(BaseEvaluator):
         is_exact_match, _ = self._exact_match_evaluator.evaluate(question,
                                                                  response,
                                                                  references)
+        # Return True if the response is an exact match
         if is_exact_match:
-            return True, {'confident': True}
+            return True, {'confident': True, 'exact_match': True}
 
-        # Provide the user with the question, references, and response
-        print(colored('Question  :\n', 'red'),
-              textwrap.indent(colored(question, 'blue'), '  '))
-        print(colored('References:', 'red'))
-        for ref in references:
-            print(textwrap.indent(ref, '  '))
-        print(colored('Response  :\n', 'red'),
-              textwrap.indent(colored(response, 'green'), '  '))
-        print(colored('Evaluation:', 'red'))
+        # Otherwise, ask a human to evaluate the response
+        return _get_human_eval(question, response, references)
 
-        # Get a valid user input
-        user_input = ''
-        while user_input not in ['y', 'n', 'yy', 'nn']:
-            user_input = input().lower()
-            if user_input not in ['y', 'n', 'yy', 'nn']:
-                print("Invalid input. Please enter 'y', 'n', 'yy', or 'nn'.")
-        print()
+    @property
+    def config(self):
+        return self._eval_config
+    
+    @property
+    def hashval(self):
+        return self._doc.doc_id
 
-        # Return the result
-        success = user_input in ['yy','y']
-        result = {'confident': user_input in ['yy','nn']}
-        return success, result
+
+class MultiHumanEvaluator(BaseEvaluator):
+    """Evaluator that asks a human to evaluate the response."""
+
+    def __init__(self, eval_config: dict):
+        self._eval_config = eval_config
+        self._doc = InfoDoc(cls='MultiHumanEvaluator',
+                            name=eval_config['name'])
+
+    def evaluate(self, question, response, references, **kwargs):
+        self_answer = None
+
+        human_eval_keys = [InfoDoc(**d).doc_id
+                           for d in self._eval_config['human-evals']]
+        answer_requested_keys = []
+
+        for key in human_eval_keys:
+            # Key of human eval we want to double-check
+            human_eval = kwargs['doc'].evaluation[key]
+
+            # Add `other-humans` if it doesn't exist, this is where
+            # our evaluation will be stored
+            if 'other-humans' not in human_eval['info']:
+                human_eval['info']['other-humans'] = {}
+            
+            print(self.hashval, human_eval['info']['other-humans'])
+            # No need to double-check if the human was confident
+            if human_eval['info']['confident']:
+                continue
+            
+            # If we have already double-checked this human, save the result
+            # (so that there is no need to ask the human to get the same
+            # result again), then skip to the next human evaluation
+            elif self.hashval in human_eval['info']['other-humans']:
+                self_answer = human_eval['info']['other-humans'][self.hashval]
+            
+            # Add to the list of unanswered human evaluations with low
+            # confidence
+            else:
+                answer_requested_keys.append(key)
+        
+        # If we have any human evaluations to double-check, and we haven't
+        # already double-checked for some other human evaluation, ask the
+        # human to evaluate the response
+        if len(answer_requested_keys)>0 and self_answer is None:
+            result, info = _get_human_eval(question, response, references)
+            self_answer = {'result': result, 'info': info}
+
+        # Save the result of the evaluation for all the requested evaluations
+        for key in answer_requested_keys:
+            kwargs['doc'].evaluation[key][
+                'info']['other-humans'][self.hashval] = self_answer
+        
+        # Update the document in the database
+        kwargs['db'].update_doc(BENCHMARK, kwargs['bm_name'],
+                                kwargs['doc'].doc_id, 'evaluation',
+                                kwargs['doc'].evaluation)
+        
+        # Returning None signals the benchmark that this evaluation does
+        # not need to be saved as its own evaluation
+        return None, None
 
     @property
     def config(self):

--- a/src/llm_eval/evaluator/llm_evaluator.py
+++ b/src/llm_eval/evaluator/llm_evaluator.py
@@ -6,6 +6,7 @@ from ..helpers.templates.evaluator import llm_evaluator as templates
 from ..helpers.constants.logging import UPDATE
 from . import logger
 
+
 class LLMEvaluator(BaseEvaluator):
     def __init__(self, eval_config: dict):
         self._eval_config = eval_config

--- a/src/llm_eval/model/hf_model.py
+++ b/src/llm_eval/model/hf_model.py
@@ -4,6 +4,7 @@ from transformers import pipeline, AutoTokenizer, AutoModelForCausalLM
 
 from .base_model import BaseModel
 from ..helpers.documents import InfoDoc
+from ..helpers.templates.model import load_template
 
 class BaseHFModel(BaseModel):
     """Base class for all HuggingFace models."""
@@ -22,13 +23,15 @@ class BaseHFModel(BaseModel):
             model_name = f'{self.HF_ORG_NAME}/{model_name}'
 
         self.tokenizer = AutoTokenizer.from_pretrained(
-            model_name, token=os.getenv('HF_TOKEN'))
+            model_name, token=os.getenv('HF_TOKEN'),
+            trust_remote_code=True)
         self.pipeline = pipeline('text-generation',
                                   model=model_name,
                                   tokenizer=self.tokenizer,
                                   torch_dtype=torch.float16,
                                   device_map='auto',
-                                  token=os.getenv('HF_TOKEN'))
+                                  token=os.getenv('HF_TOKEN'),
+                                  trust_remote_code=True)
         
         self._terminators = self.tokenizer.eos_token_id
         
@@ -61,6 +64,7 @@ class BaseHFModel(BaseModel):
 
 
 class HFModel(BaseHFModel):
+
     """Generic class for loading a HuggingFace model that does not require
     any special code.
     
@@ -88,12 +92,10 @@ class MistralModel(BaseHFModel):
 class Phi2Model(BaseHFModel):
     HF_ORG_NAME = 'microsoft'
 
-    def _predict(self, prompt: str) -> str:
-        if self._config.get('chat', False):
-            prompt = f'Instruct: {prompt}\nOutput:'
+    def __init__(self, model_config: dict):
+        raise ValueError('Phi2Model is not working correctly in this '
+                         'version of the code.')
         
-        return super()._predict(prompt)
-
 class BAAIModel(BaseHFModel):
     HF_ORG_NAME = 'BAAI'
 


### PR DESCRIPTION
Updated logic for identifying confidence by human evaluators to resolve #29.

Added a new evaluator `MultiHumanEvaluator`, closing #30.

Example usage:

1. Run a benchmark with some kind of model

```json
{
    "benchmarks": [
        {
            "name": "triviaqa-tiny",
            "cls": "TriviaQABenchmark",
            "subset": "unfiltered", 
            "seed": 51,
            "num_samples": 5,
            "num_fewshot": 5
        }
    ],
    "models" : [
        {
            "name": "human1",
            "cls": "HumanModel"
        }
    ]
}
```

2. Run a human eval on the benchmark

```json
{
    "benchmarks": [
        {
            "name": "triviaqa-tiny",
            "cls": "TriviaQABenchmark",
            "subset": "unfiltered", 
            "seed": 51,
            "num_samples": 5,
            "num_fewshot": 5
        }
    ],
    "models" : [
        {
            "name": "human1",
            "cls": "HumanModel"
        }
    ],
    "evaluators": [
        {
            "name": "human-eval1",
            "cls": "HumanEvaluator"
        }
    ]
}
```

Lets say afterwards another human did an evaluation on this benchmark, with the name `"human-eval2"`

3. Now, `human-a` wants to provide their evaluation for the low-confidence evaluations by `human-eval1` and `human-eval2` on this benchmark. Run `MultiHumanEvaluator`

```json
{
    "benchmarks": [
        {
            "name": "triviaqa-tiny",
            "cls": "TriviaQABenchmark",
            "subset": "unfiltered", 
            "seed": 51,
            "num_samples": 5,
            "num_fewshot": 5
        }
    ],
    "models" : [
        {
            "name": "human1",
            "cls": "HumanModel"
        }
    ],
    "evaluators": [
        {
            "name": "multi-human-a",
            "cls": "MultiHumanEvaluator",
            "human-evals": [
                {
                    "name": "human-eval1",
                    "cls": "HumanEvaluator"
                },
                {
                    "name": "human-eval2",
                    "cls": "HumanEvaluator"
                }
            ]
        }
    ]
}
``` 

See [this sample](https://github.com/UMass-Meta-LLM-Eval/llm_eval/files/15135879/TriviaQA.json) for how the benchmark collection would look after running the `MultiHumanEvaluator`.

Properties:

1. This is a special evaluator which breaks some norms of how evaluators usually work, since its evaluations are not added as a separate entry into the list of evaluations, but as a sub-entry to the evaluations that were being double-checked.
2. If multiple humans had low confidence in an evaluation on the same question, the double-checking human will only be asked the answer once, and that answer will be applied for all low-confidence humans.
3. If for a given question in a given benchmark, the currently double-checking human has already double-checked the answer for at least one of the humans, then that answer will be applied to any unanswered human evaluations without asking the double-checking human again.