### PR TITLE
Add error analysis option for human evaluators

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "llm_eval"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
   "numpy",
   "torch",

--- a/src/llm_eval/__init__.py
+++ b/src/llm_eval/__init__.py
@@ -1,6 +1,6 @@
 """Evaluation suite for LLMs on Core-Knowledge tasks."""
 
-__version__ = '2.0.0'
+__version__ = '2.1.0'
 """Version number of the package."""
 
 from .benchmark import create_benchmark

--- a/src/llm_eval/benchmark/mmlu.py
+++ b/src/llm_eval/benchmark/mmlu.py
@@ -57,7 +57,7 @@ class MMLUBenchmark(BaseBenchmark):
         generated = 0
         for i in self._shuffled_indices:
             # Stop if we have generated enough samples
-            if generated >= self._num_samples:
+            if generated >= self.total_questions:
                 break
 
             # Create the question and references

--- a/src/llm_eval/benchmark/naturalquestions.py
+++ b/src/llm_eval/benchmark/naturalquestions.py
@@ -17,7 +17,7 @@ class NaturalQuestionsBenchmark(BaseBenchmark):
         generated = 0
         for i in self._shuffled_indices:
             # Stop if we have generated enough samples
-            if generated >= self._num_samples:
+            if generated >= self.total_questions:
                 break
 
             # Create the question and references

--- a/src/llm_eval/benchmark/triviaqa.py
+++ b/src/llm_eval/benchmark/triviaqa.py
@@ -20,7 +20,7 @@ class TriviaQABenchmark(BaseBenchmark):
         generated = 0
         for i in self._shuffled_indices:
             # Stop if we have generated enough samples
-            if generated >= self._num_samples:
+            if generated >= self.total_questions:
                 break
 
             # Create the question and references

--- a/src/llm_eval/evaluator/human_evaluator.py
+++ b/src/llm_eval/evaluator/human_evaluator.py
@@ -5,12 +5,84 @@ from .base_evaluator import BaseEvaluator
 from .classic_evaluator import ExactMatchEvaluator
 from ..helpers import InfoDoc
 from ..helpers.constants.db import BENCHMARK
+from ..helpers.constants.evaluator import (VALID_HUMAN_INPUTS, POS_LABELS,
+                                           HIGH_CONFIDENCE_LABELS, ERROR_CODES)
+from ..helpers.misc import parse_error_codes
+from . import logger
 
 
-VALID_INPUTS = ['y', 'n', 'yy', 'nn', 'y?', 'n?']
+def _parse_input(user_input: str) -> tuple[bool, bool, bool, str]:
+    """Parse the user input for a human evaluator.
+    Human input should be the evaluation string. Returns a tuple with the
+    following elements:
+    - parsed: whether the input is valid
+    - success: whether the response is correct
+    - confident: whether the user is confident in their response
+    - parsing_error: an error message if the input is invalid
+    """
+    # Check if the input is valid
+    if user_input not in VALID_HUMAN_INPUTS:
+        return False, False, False, 'Invalid evaluation. Please enter one ' \
+            f'of {", ".join(f"{i}" for i in VALID_HUMAN_INPUTS)}'
+    
+    # Parse the evaluation
+    is_pos = user_input in POS_LABELS
+    is_high_confidence = user_input in HIGH_CONFIDENCE_LABELS
+    return True, is_pos, is_high_confidence, ''
 
 
-def _get_human_eval(question, response, references) -> tuple[bool, dict]:
+def _parse_input_with_error_codes(user_input: str
+                                  ) -> tuple[bool, bool, bool, list, str]:
+    """
+    Parse the user input for a human evaluator including error codes.
+    Human input should be of the form: `<pos_evaluation>` or
+    `<neg_evaluation> <error_codes>`. Returns a tuple with the following
+    elements:
+    - parsed: whether the input is valid
+    - success: whether the response is correct
+    - confident: whether the user is confident in their response
+    - error_codes: the error codes for the response
+    - parsing_error: an error message if the input is invalid"""
+
+    # Split the user input into the error evaluation and error codes
+    user_input = user_input.strip().split()
+    if len(user_input) == 0:
+        return False, False, False, [], 'No input provided'
+    
+    # Parse the evaluation
+    if user_input[0] not in VALID_HUMAN_INPUTS:
+        return False, False, False, [], 'Invalid evaluation. Please enter ' \
+            f'one of {", ".join(f"{i}" for i in VALID_HUMAN_INPUTS)}'
+    
+    is_high_confidence = user_input[0] in HIGH_CONFIDENCE_LABELS
+
+    # Return the parsed input if positive evaluation
+    if user_input[0] in POS_LABELS:
+        # In this case there should be no error codes
+        if len(user_input) > 1:
+            return False, False, False, [], 'Error codes should not be ' \
+                'provided for positive evaluations'
+        
+        # Valid positive evaluation
+        return True, True, is_high_confidence, [], ''
+    
+    # Parse the error codes
+    if len(user_input) == 1:
+        return False, False, False, [], 'Error codes not provided'
+    if len(user_input) > 2:
+        return False, False, False, [], 'Too many arguments provided'
+    
+    # Check if the error codes are valid
+    parsed_codes, unknown_codes = parse_error_codes(user_input[1])
+    if unknown_codes != '':
+        return False, False, False, [], f'Unknown error codes: {unknown_codes}'
+    
+    # Valid negative evaluation
+    return True, False, is_high_confidence, parsed_codes, ''
+
+
+def _get_human_eval(question, response, references, **kwargs
+                    ) -> tuple[bool, dict]:
     """Ask a human to evaluate the response."""
 
     # Provide the user with the question, references, and response
@@ -23,20 +95,28 @@ def _get_human_eval(question, response, references) -> tuple[bool, dict]:
             textwrap.indent(colored(response, 'green'), '  '))
     print(colored('Evaluation:', 'red'))
 
-    # Get a valid user input
-    user_input = ''
-    while user_input not in VALID_INPUTS:
-        user_input = input().lower()
-        if user_input not in VALID_INPUTS:
-            print('Invalid input. Please enter one of',
-                    {', '.join(f"'{i}'" for i in VALID_INPUTS)})
-    print()
-
-    # Return the result
-    success = user_input in ['yy','y', 'y?']
-    info = {'confident': user_input in ['yy','nn', 'y', 'n'],
-            'exact_match': False}
-    return success, info
+    # Ask the user to evaluate the response
+    input_valid = False
+    if kwargs.get('error_analysis', False):
+        while not input_valid:
+            logger.info('Please evaluate the response. In case of an error, '
+                        'valid error codes are: %s', ', '.join(
+                            f'{k} ({v})' for k, v in ERROR_CODES.items()))
+            user_input = input().lower()
+            input_valid, success, confident, error_codes, parsing_error = \
+                _parse_input_with_error_codes(user_input)
+            if not input_valid:
+                print(parsing_error)
+        return success, {'confident': confident, 'exact_match': False,
+                         'error_codes': error_codes}
+    else:
+        while not input_valid:
+            user_input = input().lower()
+            input_valid, success, confident, parsing_error = \
+                _parse_input(user_input)
+            if not input_valid:
+                print(parsing_error)
+        return success, {'confident': confident, 'exact_match': False}
 
 
 class HumanEvaluator(BaseEvaluator):
@@ -45,6 +125,7 @@ class HumanEvaluator(BaseEvaluator):
     def __init__(self, eval_config: dict):
         self._eval_config = eval_config
         self._exact_match_evaluator = ExactMatchEvaluator({})
+        self._error_analysis: bool = eval_config.get('error_analysis', False)
         self._doc = InfoDoc(**eval_config)
 
     def evaluate(self, question, response, references, **kwargs):
@@ -57,7 +138,8 @@ class HumanEvaluator(BaseEvaluator):
             return True, {'confident': True, 'exact_match': True}
 
         # Otherwise, ask a human to evaluate the response
-        return _get_human_eval(question, response, references)
+        return _get_human_eval(question, response, references,
+                               error_analysis=self._error_analysis)
 
     @property
     def config(self):

--- a/src/llm_eval/helpers/constants/evaluator.py
+++ b/src/llm_eval/helpers/constants/evaluator.py
@@ -5,3 +5,23 @@ TRUNCATE = 'truncate'
 
 EXTRACT = 'extract'
 """The key for the extraction tag."""
+
+VALID_HUMAN_INPUTS = ['y', 'n', 'yy', 'nn', 'y?', 'n?']
+"""The valid inputs for a human evaluator."""
+
+POS_LABELS = ['y', 'yy', 'y?']
+"""The positive labels for a human evaluator."""
+
+HIGH_CONFIDENCE_LABELS = ['y', 'n', 'yy', 'nn']
+"""The high confidence labels for a human evaluator."""
+
+ERROR_CODES = {
+    'N': 'No answer',
+    'I': 'Incorrect entity',
+    'M': 'Too many entities',
+    'F': 'Too few entities',
+    'U': 'Under-specified',
+    'C': 'Answer cut-off',
+    'O': 'Other'}
+"""The error codes and their descriptions when evaluating a response
+as incorrect."""

--- a/src/llm_eval/helpers/misc/__init__.py
+++ b/src/llm_eval/helpers/misc/__init__.py
@@ -3,9 +3,28 @@ from .. import logger
 from .io import truncate_response, extract_from_tag
 from .config_utils import (load_config, validate_config, log_config,
                            configs_to_jsonl)
+from ..constants.evaluator import ERROR_CODES
 
 
 def create_job_id() -> str:
     """Create a unique job ID based on the current time."""
     dt_curr_str = datetime.now().strftime('%Y%m%d-%H%M%S%z')
     return f'INTERACTIVE_{dt_curr_str}'
+
+
+def parse_error_codes(error_codes: str) -> tuple[list, str]:
+    """Parse a string of error codes into a list of error codes and a
+    string of unknown error codes."""
+
+    # Split the error codes into a list
+    error_code_list = list(set(e.upper() for e in error_codes))
+
+    # Check if the error codes are valid
+    errors, unknown = [], ''
+    for error in error_code_list:
+        if error in ERROR_CODES:
+            errors.append(ERROR_CODES[error])
+        else:
+            unknown += error
+
+    return errors, unknown


### PR DESCRIPTION
Human evaluation now has the option to provide error codes for answers that are evaluated as incorrect.

1. To run human evaluation in error analysis mode, provide `"error_analysis": true` option in the evaluator config. The default value is `false`
2. For correct evaluations, the expected input is the same as before, and no error codes are needed.
3. For incorrect evaluations, in response should be the negative evaluation followed by a string with all the relevant error codes. For example, `n? uc` means low-confidence negative evaluation with U (underspecification) and C (cut-off) error codes.
4. You can provide the verbosity flag `-v` when running the evaluation if you want all the error codes to be printed before each question. E.g., `python main.py -be test/human-ec -v`

Sample evaluator config:
```json
{
    ...
    "evaluators": [
        {
            "name": "human-b",
            "cls": "HumanEvaluator",
            "truncate": "newlinequestion",
            "error_analysis": true
        }
    ]
}
```

Sample data in the database after evaluation:
```json
{
    "42hZhQQn4K5QukLIjxGosf5eFUyPWapEGlqSTv9E20o=": {
        "benchmark": "aiaIXtEowsfbfU9k3zJjmr/gZQp4a8+ls8OAoQOWkCQ=",
        "model": "BaqGJu9johlW1RVzxX1oPLB0rWH2vPhia0bPQZmR3Yg=",
        "question": "TA9TaGVfGl80AP8A7I6QdRcZ1oWqE+eom7UoqkZ4y1c=",
        "prompt": ...,
        "response": ...,
        "evaluation": {
            "cs8PmNe91DCXMv438C2fMEoWA/e4wn1s7Iof/vcqXnc=": {
                "result": false,
                "info": {
                    "confident": false,
                    "exact_match": false,
                    "error_codes": [
                        "Other"
                    ]
                }
            }
        },
        "extra": {
            "num_references": 2
        }
    },
    "0nAgL/Hs3z60fLBb7ao7kqeEBEJO4K4eRNS/t6f5XyM=": {
        "benchmark": "aiaIXtEowsfbfU9k3zJjmr/gZQp4a8+ls8OAoQOWkCQ=",
        "model": "BaqGJu9johlW1RVzxX1oPLB0rWH2vPhia0bPQZmR3Yg=",
        "question": "1RVGKv16UatsUnXIwHkPD+SgSYl9gq/+nSl5C7536os=",
        "prompt": ...,
        "response": ...,
        "evaluation": {
            "cs8PmNe91DCXMv438C2fMEoWA/e4wn1s7Iof/vcqXnc=": {
                "result": false,
                "info": {
                    "confident": true,
                    "exact_match": false,
                    "error_codes": [
                        "Too many entities"
                    ]
                }
            }
        },
        "extra": {
            "num_references": 3
        }
    },
    "uGrjEyarGEXi7eNXNXYtg2crOhxdy2OoicjdTggg+eM=": {
        "benchmark": "aiaIXtEowsfbfU9k3zJjmr/gZQp4a8+ls8OAoQOWkCQ=",
        "model": "BaqGJu9johlW1RVzxX1oPLB0rWH2vPhia0bPQZmR3Yg=",
        "question": "eUpbL8UJIOi2ASjrwwbV0g5TOaMe91U2WbzCKaYmeCI=",
        "prompt": ...,
        "response": ...,
        "evaluation": {
            "cs8PmNe91DCXMv438C2fMEoWA/e4wn1s7Iof/vcqXnc=": {
                "result": false,
                "info": {
                    "confident": true,
                    "exact_match": false,
                    "error_codes": [
                        "Under-specified",
                        "Too few entities",
                        "Answer cut-off"
                    ]
                }
            }
        },
        "extra": {
            "num_references": 2
        }
    },
    "fzlYOjB45tGP5Mq4po4g01AeHgl5lpqs2RK9jAMZ6aE=": {
        "benchmark": "aiaIXtEowsfbfU9k3zJjmr/gZQp4a8+ls8OAoQOWkCQ=",
        "model": "BaqGJu9johlW1RVzxX1oPLB0rWH2vPhia0bPQZmR3Yg=",
        "question": "2tSFjmTMWlRI2jdqyYcGCeeB3lChEcaImhwkECDFWwc=",
        "prompt": ...,
        "response": ...,
        "evaluation": {
            "cs8PmNe91DCXMv438C2fMEoWA/e4wn1s7Iof/vcqXnc=": {
                "result": true,
                "info": {
                    "confident": true,
                    "exact_match": false,
                    "error_codes": []
                }
            }
        },
        "extra": {
            "num_references": 6
        }
    },
    
}
```

Other: Fixed a bug where the wrong attribute was being used by the benchmark generators.