### PR TITLE
Add OpenAI batch processing model

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "llm_eval"
-version = "2.1.1"
+version = "2.2.0"
 dependencies = [
   "numpy",
   "torch",

--- a/src/llm_eval/__init__.py
+++ b/src/llm_eval/__init__.py
@@ -1,6 +1,6 @@
 """Evaluation suite for LLMs on Core-Knowledge tasks."""
 
-__version__ = '2.1.1'
+__version__ = '2.2.0'
 """Version number of the package."""
 
 from .benchmark import create_benchmark

--- a/src/llm_eval/evaluator/base_evaluator.py
+++ b/src/llm_eval/evaluator/base_evaluator.py
@@ -28,10 +28,11 @@ class BaseEvaluator(ABC):
         """Return the SHA256 hash of the evaluator's configuration as a base64
         string."""
 
-    def exit(self):
+    def exit(self, message: str = None):
         """Perform any necessary cleanup operations."""
-        logger.log(UPDATE, 'Exiting evaluator: `%s`',
-                   self.config.get('name', 'UNKNOWN'))
+        logger.log(UPDATE, 'Exiting evaluator: `%s`. Message: %s',
+                   self.config.get('name', 'UNKNOWN'),
+                   message)
 
 
 class DummyEvaluator(BaseEvaluator):

--- a/src/llm_eval/evaluator/llm_evaluator.py
+++ b/src/llm_eval/evaluator/llm_evaluator.py
@@ -78,8 +78,14 @@ class LLMEvaluator(BaseEvaluator):
         return self._doc.doc_id
 
     def exit(self, message: str = None):
-        del self._model
+        """Perform any necessary cleanup operations."""
         super().exit(message)
+        
+        # Call exit on the model and delete the model
+        self._model.exit(message)
+        
+        logger.log(UPDATE, 'Deleting model instance.')
+        del self._model
 
 
 class LLMExtractEvaluator(LLMEvaluator):
@@ -98,7 +104,7 @@ class LLMExtractEvaluator(LLMEvaluator):
             references='\n'.join(references),
             response=response,
             extract_tag=self._extract_tag)
-    
+
     def _parse_eval(self, eval_str: str) -> tuple[bool, bool, bool]:
         extracted = extract_from_tag(eval_str, self._extract_tag)
         if extracted is not None:

--- a/src/llm_eval/evaluator/llm_evaluator.py
+++ b/src/llm_eval/evaluator/llm_evaluator.py
@@ -77,9 +77,9 @@ class LLMEvaluator(BaseEvaluator):
     def hashval(self):
         return self._doc.doc_id
 
-    def exit(self):
+    def exit(self, message: str = None):
         del self._model
-        super().exit()
+        super().exit(message)
 
 
 class LLMExtractEvaluator(LLMEvaluator):

--- a/src/llm_eval/helpers/constants/model.py
+++ b/src/llm_eval/helpers/constants/model.py
@@ -1,2 +1,21 @@
+# HuggingFace Constants
+
 HF_MAX_NEW_TOKENS = 64
 """Default maximum number of tokens to generate for a response."""
+
+# OpenAI Constants
+
+OAI_BATCH_PURPOSE = 'batch'
+"""Purpose code for batch processing."""
+
+OAI_BATCH_ENDPOINT = '/v1/chat/completions'
+"""Endpoint for batch processing requests."""
+
+OAI_BATCH_COMPLETION_WINDOW = '24h'
+"""Default completion window for batch processing requests."""
+
+OAI_BATCH_METHOD = 'POST'
+"""HTTP method for batch processing requests."""
+
+OAI_BATCH_SUCCESS = 'completed'
+"""Status code for a successfully completed batch request."""

--- a/src/llm_eval/helpers/documents/base_doc.py
+++ b/src/llm_eval/helpers/documents/base_doc.py
@@ -23,6 +23,7 @@ class BaseDoc(ABC):
     @property
     def doc_id(self) -> str:
         """Return the SHA256 hash of the object as a base64 string."""
+        # TODO: Use the helper function create_hash instead of this
         hashval = hashlib.sha256(self._encode()).digest()
         return base64.b64encode(hashval).decode('utf-8')
     

--- a/src/llm_eval/helpers/misc/__init__.py
+++ b/src/llm_eval/helpers/misc/__init__.py
@@ -1,9 +1,34 @@
 from datetime import datetime
+from typing import Union
+import base64
+import json
+import hashlib
+
 from .. import logger
 from .io import truncate_response, extract_from_tag
 from .config_utils import (load_config, validate_config, log_config,
                            configs_to_jsonl)
 from ..constants.evaluator import ERROR_CODES
+
+
+def create_hash(item: Union[str, dict, bytes]) -> str:
+    """Create the SHA256 hash of the given item. Returns the base64
+    encoded hash."""
+
+    # Convert the item to bytes
+    if isinstance(item, dict):
+        item = json.dumps(item, sort_keys=True)
+    if isinstance(item, str):
+        item = item.encode('utf-8')
+    
+    # Create the hash
+    hashval = hashlib.sha256(item).digest()
+
+    # Encode the hash as a base64 string
+    hash_str = base64.b64encode(hashval).decode('utf-8')
+
+    # Return the hash string
+    return hash_str
 
 
 def create_job_id() -> str:

--- a/src/llm_eval/model/__init__.py
+++ b/src/llm_eval/model/__init__.py
@@ -8,6 +8,8 @@ from .hf_model import HFModel, LlamaModel, MistralModel, Phi2Model, BAAIModel
 from .human_model import HumanModel
 from .openai_model import OpenAIModel
 from .anthropic_model import AnthropicModel
+from .openai_batch_model import (OpenAIBatchRequestModel,
+                                 OpenAIBatchRetrieveModel)
 
 classes = {
     'DummyModel': DummyModel,
@@ -21,6 +23,8 @@ classes = {
     'AnthropicModel': AnthropicModel,
     'BAAIModel': BAAIModel,
     'ReferenceModel': ReferenceModel,
+    'OpenAIBatchRequestModel': OpenAIBatchRequestModel,
+    'OpenAIBatchRetrieveModel': OpenAIBatchRetrieveModel,
     # Add new models here
 }
 

--- a/src/llm_eval/model/base_model.py
+++ b/src/llm_eval/model/base_model.py
@@ -34,6 +34,11 @@ class BaseModel(ABC):
         """Return the SHA256 hash of the model's configuration as a base64
         string."""
 
+    def exit(self, message: str = None):
+        """Perform any necessary cleanup operations."""
+        logger.log(UPDATE, 'Exiting model: `%s`. Message: %s',
+                   self.config.get('name', 'UNKNOWN'),
+                   message)
 
 class DummyModel(BaseModel):
     """A dummy model that simply returns the prompt with a prefix and

--- a/src/llm_eval/model/openai_batch_model.py
+++ b/src/llm_eval/model/openai_batch_model.py
@@ -124,7 +124,7 @@ class OpenAIBatchRetrieveModel(OpenAIModel):
 
         return False
 
-    def _retrieve_batch_results(self, verify: bool = True):
+    def _retrieve_batch_results(self, verify: bool = True) -> list[dict]:
         """Retrieve the results for a completed batch job corresponding the to
         the given batch ID after optinally checking for successful completion
         first."""

--- a/src/llm_eval/model/openai_batch_model.py
+++ b/src/llm_eval/model/openai_batch_model.py
@@ -74,23 +74,21 @@ class OpenAIBatchRequestModel(OpenAIModel):
 class OpenAIBatchRetrieveModel(OpenAIModel):
     def __init__(self, model_config: dict):
         super().__init__(model_config)
-        
+
         try:
             self._batch_id = model_config['batch_id']
         except KeyError as e:
             logger.error('`batch_id` not found in model configuration.')
             raise ValueError('Batch ID needs to be provided in model '
                              'configuration.') from e
-        
+
         # Boolean to enable lazy retrieval of results
         self._retrieved: bool = False
         self._results: dict[str, dict] = {}
 
     def _set_results(self):
-        results_list = self._retrieve_batch_results(self._batch_id,
-                                                    success=OAI_BATCH_SUCCESS,
-                                                    verify=True)
-        
+        results_list = self._retrieve_batch_results(verify=True)
+
         self._results = self._results_to_dict(results_list)
         self._retrieved = True
 
@@ -129,8 +127,7 @@ class OpenAIBatchRetrieveModel(OpenAIModel):
         the given batch ID after optinally checking for successful completion
         first."""
         if verify:
-            self._verify_batch_completion(self._batch_id, OAI_BATCH_SUCCESS,
-                                          raise_on_failure=True)
+            self._verify_batch_completion(raise_on_failure=True)
 
         batch_info = self.client.batches.retrieve(self._batch_id)
         output_file_id: str = batch_info.output_file_id

--- a/src/llm_eval/model/openai_batch_model.py
+++ b/src/llm_eval/model/openai_batch_model.py
@@ -1,0 +1,157 @@
+import json
+from tempfile import NamedTemporaryFile
+
+from ..helpers.constants.model import (OAI_BATCH_PURPOSE, OAI_BATCH_ENDPOINT,
+                                       OAI_BATCH_COMPLETION_WINDOW,
+                                       OAI_BATCH_METHOD, OAI_BATCH_SUCCESS)
+from ..helpers.misc import create_hash
+from ..helpers.constants.logging import UPDATE
+from .openai_model import OpenAIModel
+from . import logger
+
+
+class OpenAIBatchRequestModel(OpenAIModel):
+    def __init__(self, model_config: dict):
+        super().__init__(model_config)
+        self._request_data: list[dict] = []
+
+    def _upload_jsonl(self, data: list[dict], purpose: str) -> str:
+        """Upload the given data for the given purpose to OpenAI
+        using the OpenAI client. Returns the file ID of the
+        uploaded data."""
+        with NamedTemporaryFile(suffix='.jsonl') as f:
+            for item in data:
+                line = json.dumps(item)+'\n'
+                f.write(line.encode('utf-8'))
+            file_response = self.client.files.create(file=f.file,
+                                                     purpose=purpose)
+            return file_response.id
+
+    def _submit_batch_request(self, data: list[dict]) -> str:
+        """Submit a batch processing request with the given data
+        to OpenAI using the OpenAI client. Returns the batch ID
+        of the submitted job."""
+        file_id = self._upload_jsonl(data, purpose=OAI_BATCH_PURPOSE)
+        batch_response = self.client.batches.create(
+            input_file_id=file_id,
+            endpoint=OAI_BATCH_ENDPOINT,
+            completion_window=OAI_BATCH_COMPLETION_WINDOW)
+        return batch_response.id
+    
+    def _predict(self, prompt: str, **kwargs) -> str:
+        prompt_hash = create_hash(prompt)
+        messages = [{'role': 'user', 'content': prompt}]
+        request_object = {
+            'custom_id': prompt_hash,
+            'method': OAI_BATCH_METHOD,
+            'url': OAI_BATCH_ENDPOINT,
+            'body': {
+                'model': self._config['model'],
+                'messages': messages,
+                **self._completions_kwargs}}
+        self._request_data.append(request_object)
+        
+        return f'success ({prompt_hash[-4:]})'
+
+    @property
+    def request_count(self) -> int:
+        return len(self._request_data)
+
+    def exit(self, message: str = None) -> str:
+        """Send the accumulated prompts as a batch request to OpenAI and
+        return the ID of the submitted batch request."""
+
+        logger.log(UPDATE, 'Creating and submitting batch request with %d '
+                   'items.', self.request_count)
+
+        batch_id: str = self._submit_batch_request(self._request_data)
+        logger.log(UPDATE, 'Batch request submitted with ID: `%s`.', batch_id)
+
+        super().exit(message)
+
+        return batch_id
+
+class OpenAIBatchRetrieveModel(OpenAIModel):
+    def __init__(self, model_config: dict):
+        super().__init__(model_config)
+        
+        try:
+            self._batch_id = model_config['batch_id']
+        except KeyError as e:
+            logger.error('`batch_id` not found in model configuration.')
+            raise ValueError('Batch ID needs to be provided in model '
+                             'configuration.') from e
+        
+        # Boolean to enable lazy retrieval of results
+        self._retrieved: bool = False
+        self._results: dict[str, dict] = {}
+
+    def _set_results(self):
+        results_list = self._retrieve_batch_results(self._batch_id,
+                                                    success=OAI_BATCH_SUCCESS,
+                                                    verify=True)
+        
+        self._results = self._results_to_dict(results_list)
+        self._retrieved = True
+
+    def _download_jsonl(self, file_id: str) -> list[dict]:
+        """Download the data corresponding to the give file ID
+        from OpenAI using the OpenAI client. Returns the
+        downloaded data."""
+        content = self.client.files.content(file_id)
+        content_lines = content.read().decode().splitlines()
+        result_data = []
+        for line in content_lines:
+            result_data.append(json.loads(line))
+        return result_data
+
+    def get_batch_status(self) -> str:
+        """Get the status of a batch job with the given batch ID."""
+        batch_info = self.client.batches.retrieve(self._batch_id)
+        return batch_info.status
+
+    def _verify_batch_completion(self, raise_on_failure: bool = True) -> bool:
+        """Verify if a batch job with the given batch ID has been completed
+        and optionally raise an error on failure."""
+        status = self.get_batch_status()
+
+        if status == OAI_BATCH_SUCCESS:
+            return True
+
+        if raise_on_failure:
+            raise RuntimeError(f'Batch completion for batch ID: `{self._batch_id}` '
+                f' could not be verified. Status: `{status}`.')
+
+        return False
+
+    def _retrieve_batch_results(self, verify: bool = True):
+        """Retrieve the results for a completed batch job corresponding the to
+        the given batch ID after optinally checking for successful completion
+        first."""
+        if verify:
+            self._verify_batch_completion(self._batch_id, OAI_BATCH_SUCCESS,
+                                          raise_on_failure=True)
+
+        batch_info = self.client.batches.retrieve(self._batch_id)
+        output_file_id: str = batch_info.output_file_id
+        return self._download_jsonl(output_file_id)
+    
+    def _results_to_dict(self, results_list: list[dict]) -> dict[str, dict]:
+        """Convert a list of results to a dictionary indexed by the
+        custom ID."""
+
+        results_dict = {}
+        for result in results_list:
+            custom_id = result['custom_id']
+            results_dict[custom_id] = result
+        
+        return results_dict
+
+    def _predict(self, prompt: str, **kwargs) -> str:
+        # Lazily retrieve results if not already done
+        if not self._retrieved:
+            self._set_results()
+
+        prompt_hash = create_hash(prompt)
+        result = self._results[prompt_hash]
+        return result['response']['body']['choices'][0]['message']['content']

--- a/src/llm_eval/model/openai_model.py
+++ b/src/llm_eval/model/openai_model.py
@@ -7,10 +7,11 @@ from ..helpers.documents import InfoDoc
 class OpenAIModel(BaseModel):
     def __init__(self, model_config: dict):
         self._config = model_config
-        client_kwargs = self._config.get('client_kwargs', {})
+        client_kwargs: dict = self._config.get('client_kwargs', {})
         self.client = OpenAI(api_key=os.getenv('OPENAI_API_KEY'),
                              **client_kwargs)
-        self._completions_kwargs = self._config.get('completions_kwargs', {})
+        self._completions_kwargs: dict = self._config.get('completions_kwargs',
+                                                          {})
         self._doc = InfoDoc(**model_config)
 
     def _predict(self, prompt: str, **kwargs) -> str:


### PR DESCRIPTION
# Summary

Added two new derived classes of the `OpenAIModel` class: `OpenAIBatchRequestModel` and `OpenAIBatchRetrieveModel` enabling the use of batch processing for OpenAI API calls, for a **50% cost reduction**.

# Technical Details

The parameters for the `OpenAIBatchRequestModel` are the exact same as the `OpenAIModel`. The difference is that instead of making individual API calls for each `.predict()` call, the model accumulates all the requests, giving placeholder responses. When the `.exit()` method is called (such as at the end of a benchmark or evaluation), all the accumulated requests are sent to OpenAI as a batch job, and the batch ID is generated that can later be used to retrieve the actual results.

The parameters for the `OpenAIBatchRetrieveModel` are also the same as the `OpenAIModel`, with the exception of an additional parameter `batch_id` that is required. The results of a completed batch job are then retrieved using this batch ID and, if the batch job has been completed, calling the `.predict()` method behaves the exact same way as if the normal `OpenAIModel` was being used. If there is an attempt to retrieve the results before the batch is completed, a `RuntimeError` is thrown. The status of a job can be verified before retrieval using the `.get_batch_status()` method.

# Usage

Usage as either an evaluation model or a judge model involves two stages: Sending a batch request using the `OpenAIBatchRequestModel`, and retrieving the results using the `OpenAIBatchRetrieveModel`.

## Use as evaluation model

In the first stage, the benchmark is run in the exact same way as the synchronous `OpenAIModel` is run, with the exception of the `cls` parameter changing to `OpenAIBatchRequestModel`. See the demo config below for an example:

```json
{
    "benchmarks": [
        {
            "name": "triviaqa-tiny",
            "cls": "TriviaQABenchmark",
            "subset": "unfiltered", 
            "seed": 51,
            "num_samples": 5,
            "num_fewshot": 5,
            "template": "BASE_SIMPLE"
        }
    ],
    "models" : [
        {
            "name": "gpt-35-batch",
            "cls": "OpenAIBatchRequestModel",
            "model": "gpt-3.5-turbo",
            "chat": true
        }
    ]
}
```

The results from this benchmark are only placeholders and should not be used anywhere. Once the benchmark is complete, the batch ID (of the form `batch_xxxx`) of the job will be generated and output in the logs with a log level of `UPDATE`. This batch ID needs to be saved for the next stage.

The next stage can only be started after the batch has finished processing, which is guaranteed to happen in 24 hours, but usually happens much faster. To check the status of the job, the `.get_batch_status()` method can be called, as seen in the following example:

```python
from llm_eval import create_model

model = create_model({
    "name": "gpt-35-batch",
    "cls": "OpenAIBatchRetrieveModel",
    "model": "gpt-3.5-turbo",
    "batch_id": "batch_xxxx",
    "chat": True})

print(model.get_batch_status())

>>> completed
```

Once the batch status says `"completed"`, that means the results can be retrieved using the `OpenAIBatchRetrieveModel`. The config would look the exact same except the change in `cls` and the additional `batch_id` parameter.

```json
{
    "benchmarks": [
        {
            "name": "triviaqa-tiny",
            "cls": "TriviaQABenchmark",
            "subset": "unfiltered", 
            "seed": 51,
            "num_samples": 5,
            "num_fewshot": 5,
            "template": "BASE_SIMPLE"
        }
    ],
    "models" : [
        {
            "name": "gpt-35-batch",
            "cls": "OpenAIBatchRetrieveModel",
            "model": "gpt-3.5-turbo",
            "batch_id": "batch_xxxx",
            "chat": true
        }
    ]
}
```

For all intents and purposes, this can be considered to be the "real" config that should be used for all experiments, etc. The config with `OpenAIBatchRequestModel` can be thought of like a primer config that needs to be run in order for the "real" config to be able to run correctly. Once the primer is run, `OpenAIBatchRetrieveModel` behaves the exact same way as `OpenAIModel`.

## Use as a judge model

Use as a judge model follows the same procedure as using as an evaluation model. First, run the evaluator using the `OpenAIBatchRequestModel` class:

```json
{
    "benchmarks": [
        {
            "name": "triviaqa-tiny",
            "cls": "TriviaQABenchmark",
            "subset": "unfiltered", 
            "seed": 51,
            "num_samples": 5,
            "num_fewshot": 5,
            "template": "BASE_SIMPLE"
        }
    ],
    "models" : [
        {
            "name": "gpt-35-batch",
            "cls": "OpenAIBatchRetrieveModel",
            "model": "gpt-3.5-turbo",
            "batch_id": "batch_xxxx",
            "chat": true
        }
    ],
    "evaluators": [
        {
            "name": "eval-gpt-35-batch",
            "cls": "LLMEvaluator",
            "model_config": {
                "cls": "OpenAIBatchRequestModel",
                "model": "gpt-3.5-turbo",
                "chat": true
            },
            "truncate": "newlinequestion",
            "template": "DEFAULT_V2"
        }
    ]
}
```

In this case, we are evaluating the (already completed) batch GPT-3.5 benchmark results with a batch GPT-3.5 evaluator. This run will also result in placeholder outputs and a batch ID in the logs. Using that batch ID, the "real" evaluation can be run once the batch has been processed.

```json
{
    "benchmarks": [
        {
            "name": "triviaqa-tiny",
            "cls": "TriviaQABenchmark",
            "subset": "unfiltered", 
            "seed": 51,
            "num_samples": 5,
            "num_fewshot": 5,
            "template": "BASE_SIMPLE"
        }
    ],
    "models" : [
        {
            "name": "gpt-35-batch",
            "cls": "OpenAIBatchRetrieveModel",
            "model": "gpt-3.5-turbo",
            "batch_id": "batch_xxxx",
            "chat": true
        }
    ],
    "evaluators": [
        {
            "name": "eval-gpt-35-batch",
            "cls": "LLMEvaluator",
            "model_config": {
                "cls": "OpenAIBatchRetrieveModel",
                "model": "gpt-3.5-turbo",
                "batch_id": "batch_yyyy",
                "chat": true
            },
            "truncate": "newlinequestion",
            "template": "DEFAULT_V2"
        }
    ]
}
```

This, again, would behave in the exact same manner as an `LLMEvaluator` that is using the `OpenAIModel` class.