### PR TITLE
Made model response deterministic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "llm_eval"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
   "numpy",
   "torch",

--- a/src/llm_eval/__init__.py
+++ b/src/llm_eval/__init__.py
@@ -1,6 +1,6 @@
 """Evaluation suite for LLMs on Core-Knowledge tasks."""
 
-__version__ = '2.2.0'
+__version__ = '2.2.1'
 """Version number of the package."""
 
 from .benchmark import create_benchmark

--- a/src/llm_eval/model/hf_model.py
+++ b/src/llm_eval/model/hf_model.py
@@ -56,7 +56,8 @@ class BaseHFModel(BaseModel):
             pad_token_id=self.tokenizer.eos_token_id,
             max_new_tokens=self._config.get('max_new_tokens',
                                             HF_MAX_NEW_TOKENS),
-            return_full_text=False)
+            return_full_text=False,
+            do_sample=False)
 
         response: str = sequences[0]['generated_text']
         return response.strip()
@@ -126,7 +127,8 @@ class BAAIModel(BaseHFModel):
         sequences = self.pipeline.generate(
             **self.tokenizer(prompt, return_tensors='pt').to('cuda'),
             max_new_tokens=self._config.get('max_new_tokens',
-                                            HF_MAX_NEW_TOKENS))
+                                            HF_MAX_NEW_TOKENS),
+            do_sample=False)
         response = self.tokenizer.decode(sequences[0])
 
         if response.startswith(self.starttoken):

--- a/src/llm_eval/model/openai_model.py
+++ b/src/llm_eval/model/openai_model.py
@@ -19,6 +19,8 @@ class OpenAIModel(BaseModel):
         response = self.client.chat.completions.create(
             model=self._config['model'],
             messages=messages,
+            temperature=0,
+            seed=self._config.get('seed', 0),
             **self._completions_kwargs).choices[0].message.content
         return response
 


### PR DESCRIPTION
Made responses for OpenAI and HuggingFace models deterministic.

**Note:** As per [OpenAI documentation](https://platform.openai.com/docs/api-reference/chat/create#chat-create-seed), even specifying seed does not guarantee deterministic output, although they would try their "best". As a test, after asking GPT-3.5 Turbo the question "How to bake a cake?" 10 times with the same seed and 0 temperature, the model responded with 7 different unique responses (although they were very close to each other, with only a word or two different here and there).